### PR TITLE
Fix incorrect file reference in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bin": {
     "ramllint": "./src/cli.js"
   },
-  "main": "src/ramllint.js",
+  "main": "src/linter.js",
   "dependencies": {
     "raml2obj": "^2.0.0"
   },


### PR DESCRIPTION
The `main` entry in [`package.json`](https://github.com/QuickenLoans/ramllint/blob/dad83323f086d0d727fc995327f148dc9535689b/package.json#L20) references `src/ramllint.js`. This pull request changes that reference to point at `src/linter.js`, which `ramllint.js` was renamed to in 7c7cda8.