### PR TITLE
Return instance of log in callback rather than only errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,10 @@ var Linter = require('ramllint'),
 
     ramllint = new Linter();
 
-ramllint('./path/to/api.raml', function (results) {
-   // NOTE: results will only contain 'error' and will exclude 'warning' and 'info'
-   // to get an array of all log entries use: `ramllint.results()`
+ramllint('./path/to/api.raml', function (log) {
+  var errors = log.read('error');
 
-  if (!results.length) {
+  if (!errors.length) {
     // no errors, all rules are satisfied
   } else {
     // errors

--- a/src/linter.js
+++ b/src/linter.js
@@ -157,7 +157,7 @@ function Linter(options) {
     * @callback LinterCallback
     * @description
     * The function to handle the results of linting the RAML document.
-    * @arg {LogEntry[]} results
+    * @arg {Log} log
     */
 
   /**
@@ -166,41 +166,23 @@ function Linter(options) {
     * @arg {string} raml - the RAML document as a string or filepath.
     * @arg {LinterCallback} callback - the callback to receive the linting results.
     * @example
-    * basicLinter.lint(myRAML, function (results) {
-    *   // check results for entries; if none, no errors were encountered
+    * basicLinter.lint(myRAML, function (log) {
+    *   // check log for errors
+    *   if (log.read('error')) {
+    *     // report errors
+    *   }
     * });
     */
   this.lint = function lint(raml, callback) {
     log.empty();
 
-    // when the parser is done send back the log to indicate failure/success
-    function resolve() {
-      callback(log.read('error'));
-    }
-
     return parser
       .parse(raml)
       .then(lintRoot.bind(this, rules), log.raw)
-      .finally(resolve);
+      .finally(function resolve() {
+        callback(log);
+      });
   };
-
-  /**
-    * @description
-    * Provide a way to get all results in log; the callback in the {@link Linter#lint}
-    * method only returns errors by default to be permissive of customizations.
-    * @see {@link Log#read}
-    * @example
-    * // while this is possible, it is probably less helpful than the next example
-    * myLinter.results(); // returns an array of all log entries collected
-    * @example
-    * myLingter.lint(myRAML, function () {
-    *   // ignoring callback argument
-    *
-    *   // using the collection of all log entries for this round of linting
-    *   myLinter.results(); // returns all log entries
-    * });
-    */
-  this.results = log.read;
 }
 
 /* istanbul ignore else */

--- a/test/linter.js
+++ b/test/linter.js
@@ -59,7 +59,7 @@ describe('RAML Linter', function () {
   it('should fail with parse_error', function () {
     // async
     return ramllint.lint('', function (log) {
-      var result = ramllint.results();
+      var result = log.read();
 
       assert.equal(result.length, 1);
       assert.equal(result[0].name, 'YAMLError');
@@ -70,7 +70,7 @@ describe('RAML Linter', function () {
     // async
     ramllint.lint(passing, function (log) {
       try {
-        assert.equal(log.length, 0);
+        assert.equal(log.read().length, 0);
         done();
       } catch (e) {
         //console.log(passing);
@@ -110,10 +110,10 @@ describe('RAML Linter', function () {
   it('should skip rules', function (done) {
     var myLinter = new Linter({api_version: false});
 
-    myLinter.lint(passing, function (results) {
+    myLinter.lint(passing, function (log) {
       try {
-        assert.equal(results.length, 0);
-        assert(hasError(myLinter.results(), 'api_version'));
+        assert.equal(log.read('error').length, 0);
+        assert(hasError(log.read(), 'api_version'));
         done();
       } catch (e) {
         done(e);
@@ -128,23 +128,27 @@ describe('RAML Linter', function () {
       section = section.name;
 
       it('should fail in ' + section, function (done) {
-        ramllint.lint(doc, function (report) {
+        ramllint.lint(doc, function (log) {
+          var results;
+
           try {
+            results = log.read();
+
             // 1. (positive) check that all defined rules for section are not passing
             rules[section]
               .forEach(function (rule) {
-                assert(hasError(report, rule), 'The error log should include an error for: ' + rule);
+                assert(hasError(results, rule), 'The error log should include an error for: ' + rule);
               });
 
             // 2. (negative) check that no other errors are reported for section
-            assert.equal(report.length, rules[section].length, 'Length of error report does not match expected length.');
+            assert.equal(results.length, rules[section].length, 'Length of error report does not match expected length.');
 
             // 3. (negative) check that errors for previous sections are not reported
 
             done(); // async
           } catch (e) {
             console.log(doc);
-            console.log(report);
+            console.log(results);
             done(e); // this is stupid (node)assert/mochajs
           }
         });


### PR DESCRIPTION
It makes more sense to return the instance of Log, for a given lint run, in place
of the copy of just the errors, for the lint run, in the callback. This remove
the need to expose it as an instance method of the linter.

Closes #18