### PR TITLE
Added ability to add rules when creating linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "ramllint",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "RAML Lint",
   "author": "Tyler Smith <TylerSmith@quickenloans.com",
   "contributors": [
     "Joshua T Kalis <KalisJoshua@gmail.com>",
-    "Jorden Lowe <JordenLowe@quickenloans.com>"
+    "Jorden Lowe <JordenLowe@quickenloans.com>",
+    "Mark Morga <mmorga@rackspace.com"
   ],
   "repository": {
     "type": "git",

--- a/src/linter.js
+++ b/src/linter.js
@@ -142,12 +142,21 @@ function lintRoot(rules, context) {
   * Creates a new instance with the given options; passed in options are merged
   * with defaults.
   * @arg {Options} options - configuration options from project based prefs file.
-  * @example
-  * // using only default rule definitions
+  * @example <caption>Using only default rule definitions</caption>
   * var basicLinter = new Linter();
-  * @example
-  * // passing in customizations
+  * @example <caption>Disable (skip) the <code>api_version</code> rule</caption>
   * var myLinter = new Linter({api_version: false});
+  * @example <caption>Enable (default) the <code>api_version</code> rule</caption>
+  * var myLinter = new Linter({api_version: true});
+  * @example <caption>Change test regexp for the <code>url_lower</code> rule</caption>
+  * var myLinter = new Linter({url_lower: "^\\/([a-z]+(-[a-z]+)*|{[a-z]+([A-Z][a-z]+)*})$"});
+  * @example <caption>Add a new rule to the <code>resource</code> section</caption>
+  * var myLinter = new Linter({
+      resource: [{id:   'url_plural', prop: 'relativeUri',
+      test: '[s}]$',
+      text: 'RAML section ({section}) {property} violates: should be plural'
+      }]});
+  * @see {@link Rules#Rules} for more information
   */
 function Linter(options) {
   var log = new Log(),

--- a/src/rules.js
+++ b/src/rules.js
@@ -113,6 +113,17 @@ function mapRules(options, rule) {
   return custom;
 }
 
+function mergeSectionWithOptions(options, allRules, section) {
+  allRules[section] = options[section].reduce(function merge(rules, newRule) {
+    rules[rules.reduce(function findRuleById(foundIdx, checkRule, idx) {
+        return (checkRule.id === newRule.id) ? idx : foundIdx;
+      }, rules.length)] = newRule;
+
+    return rules;
+  }, allRules[section]);
+  return allRules;
+}
+
 /**
   * @private
   * @description
@@ -170,6 +181,12 @@ function Rules(logger, options) {
 
       return full;
     }, {});
+
+  if (options) {
+    this.rules = Object.keys(options)
+      .filter(function isDefaultSection(section) { return section in defaults; })
+      .reduce(mergeSectionWithOptions.bind(null, options), this.rules);
+  }
 
   this.logger = logger;
 }

--- a/test/rules.js
+++ b/test/rules.js
@@ -27,4 +27,43 @@ describe('Rules', function () {
 
     assert.notDeepEqual(custom.rules, standard.rules);
   });
+
+  it('should accept a custom set of rules', function () {
+    var custom = new Rules(log, {
+      resource: [{
+        id: 'url_plural',
+        prop: 'relativeUri',
+        test: '[s}]$',
+        text: 'RAML section ({section}) {property} violates: should be plural'
+      }]
+    });
+
+    assert.notDeepEqual(custom.rules, config.rules);
+    assert.equal('url_plural', custom.rules.resource[custom.rules.resource.length - 1].id);
+  });
+
+  it('should replace a default rule with a custom rule of the same section and id', function () {
+    var rules = {
+        resource: [{
+          hint: '/income-tax-documents (good)\n/incomeTaxDocuments (bad)\n/Income_Tax_Documents (bad)',
+          id: 'url_lower',
+          prop: 'relativeUri',
+          test: '^\\/([a-z]+(-[a-z]+)*|{[a-z]+([A-Z][a-z]+)*})$',
+          text: 'RAML section ({section}) {property} violates: only lowercase letters and dashes allowed. URI Params must be camel cased.'
+        }]
+      },
+      custom2 = new Rules(log, rules),
+      ruleIdx = 1;
+
+    assert.notDeepEqual(custom2.rules, config.rules);
+    assert.equal(config.rules.resource.length, custom2.rules.resource.length);
+    ruleIdx = config.rules.resource.reduce(function (foundIdx, rule, index) {
+      if (rule.id === 'url_lower') {
+        foundIdx = index;
+      }
+      return foundIdx;
+    });
+    assert.deepEqual(rules.resource[0], custom2.rules.resource[ruleIdx]);
+  });
+
 });


### PR DESCRIPTION
New rules can be added following the:
```js
var Linter = require('ramllint'),
  ramllint = new Linter({
    resource: {
      hint: '/income-tax-documents (good)\n/incomeTaxDocuments (bad)\n/Income_Tax_Documents (bad)',
      id: 'url_format',
      prop: 'relativeUri',
      test: '^\\/([a-z]+(-[a-z]+)*|{[a-z]+([A-Z][a-z]+)*})$',
      text: 'RAML section ({section}) {property} violates: only lowercase letters and dashes allowed. URI Params must be camel cased.'
    }
  }); 
```

Updated release tag to 1.2.3

Adding a rule in the same section with a default rule with a matching id replaces
the default rule.