### PR TITLE
Update usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var Linter = require('ramllint'),
 
     ramllint = new Linter();
 
-ramllint('./path/to/api.raml', function (results) {
+ramllint.lint('./path/to/api.raml', function (results) {
    // NOTE: results will only contain 'error' and will exclude 'warning' and 'info'
    // to get an array of all log entries use: `ramllint.results()`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ramllint",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "RAML Lint",
   "author": "Tyler Smith <TylerSmith@quickenloans.com",
   "contributors": [


### PR DESCRIPTION
- Looking at the source code, the prototype of Linter
  exposes a .lint function which takes the path of
  the RAML file as well as a callback which is
  used to process the results.
- Patch version bumped, this is necessary as npm needs a new version bump to update the docs accordingly.

Specifically this line:
https://github.com/QuickenLoans/ramllint/blob/master/src/linter.js#L173
```javascript
//snippet
this.lint = function lint(raml, callback) {
```

  Closes #50 
