### PR TITLE
Log succesful tests

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -64,6 +64,8 @@ function Log() {
     * myLogger.warning('resource', 'resource_desc', 'need a description', 'GET http://example.com/resource');
     * @example
     * myLogger.info('resource', 'resource_desc', 'need a description', 'GET http://example.com/resource');
+    * @example
+    * myLogger.success('resource', 'resource_desc', 'need a description', 'GET http://example.com/resource');
     */
   function addEntry(level, section, rule, message, locale) {
     if ([section, rule, message, locale].every(isDef)) {
@@ -107,6 +109,16 @@ function Log() {
     * @instance
     * @description
     * Instance method for logging `info` level entries; calls {@link Log~addEntry}
+    * with first argument satisfied, and passing along addition arguments.
+    * @see {@link Log~addEntry}
+    */
+
+  /**
+    * @function success
+    * @memberOf Log
+    * @instance
+    * @description
+    * Instance method for logging `success` level entries; calls {@link Log~addEntry}
     * with first argument satisfied, and passing along addition arguments.
     * @see {@link Log~addEntry}
     */
@@ -157,17 +169,17 @@ function Log() {
   * @returns {array} a list of all logging levels; in descending order of severity
   * @example
   * // this is the constructor (function); not an instance of it
-  * Log.getLevels(); // returns ['error', 'warning', 'info']
+  * Log.getLevels(); // returns ['error', 'warning', 'info', 'success']
   */
 Log.getLevels = function getLevels() {
 
-  return ['error', 'warning', 'info'];
+  return ['error', 'warning', 'info', 'success'];
 };
 
 /**
   * @see {@link Log.getLevels}
   * @example
-  * myLoggerInstance.getLevels(); // returns ['error', 'warning', 'info']
+  * myLoggerInstance.getLevels(); // returns ['error', 'warning', 'info', 'success']
   */
 Log.prototype.getLevels = Log.getLevels;
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -190,6 +190,8 @@ Rules.prototype.run = function runRules(section, context) {
     } else {
       if (!passing(rule, context)) {
         logger.error(section, rule, format(section, rule), context.lintContext);
+      } else {
+        logger.success(section, rule, format(section, rule), context.lintContext);
       }
     }
   }

--- a/test/log.js
+++ b/test/log.js
@@ -124,7 +124,7 @@ describe('log', function () {
   });
 
   it('should provide a list of levels', function () {
-    assert.deepEqual(['error', 'warning', 'info'], log.getLevels());
+    assert.deepEqual(['error', 'warning', 'info', 'success'], log.getLevels());
   });
 
   it('should throw errors when arguments are omitted', function () {


### PR DESCRIPTION
Logging succesful tests allows to collect and display passed tests or simply count them.

Example use case: JUnit-like XML result should be in format:

```
<?xml version="1.0" encoding="UTF-8"?>
<testsuite tests="110" failures="3">
    <failure type="POST http://example.com/resource" message="RAML section - method - must include: description"/>
    <failure type="POST http://example.com/resource" message="RAML section - method - must include: examples"/>
    <failure type="POST http://example.com/resource" message="RAML section - method - must include: schemas"/>
</testsuite>
```

To count the total number of tests you need to add `results('success').length` and `results('error').length`.